### PR TITLE
added arch to config.json

### DIFF
--- a/Homegear/config.json
+++ b/Homegear/config.json
@@ -25,5 +25,11 @@
   "devices": [
     "/dev/ttyAMA0:/dev/ttyAMA0:rwm",
     "/dev/ttyACM0:/dev/ttyACM0:rwm"
+  ],
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armv7",
+    "i386"
   ]
 }


### PR DESCRIPTION
the current version of hassio needs the "arch" attribute in the config.json